### PR TITLE
Adds additional context for the triggered build

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -2,10 +2,13 @@
 
 set -euo pipefail
 
-mode="checkout"
-if [[ -v BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE ]]; then
-  mode="${BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE}"
+if [[ "${GITHUB_MERGED_PR_BUILD_TYPE:-}" == "merged" ]]; then
+  echo "--- Skipping merged PR plugin (already running merged build)"
+else
+  export GITHUB_MERGED_PR_BUILD_TYPE=""
 fi
+
+mode="${BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE:-checkout}"
 
 function trigger_merged_build() {
   local slug="${BUILDKITE_PIPELINE_SLUG}"
@@ -19,6 +22,8 @@ function trigger_merged_build() {
     build:
       message: "Merge build for Pull Request ${pr}"
       branch: "${ref}"
+      env:
+        GITHUB_MERGED_PR_BUILD_TYPE: "merged"
 EOL
 }
 


### PR DESCRIPTION
This allows the merged build PR to run as if it's a PR build, additionally `GITHUB_MERGED_PR_BUILD_TYPE` is exposed for consumers