### PR TITLE
Feature/improve noninteractivity

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -34,7 +34,7 @@ merge() {
   export GIT_COMMITTER_EMAIL="foo@bar"
   export GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin"
   export GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
-  git merge "${BUILDKITE_COMMIT} "
+  git merge "${BUILDKITE_COMMIT}"
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -30,7 +30,11 @@ merge() {
   git fetch -v origin "${target_branch}"
   git checkout FETCH_HEAD
   # env vars to ensure merge is non-interactive
-  GIT_MERGE_AUTOEDIT="no" GIT_COMMITTER_EMAIL="foo@bar" GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin" git merge "${BUILDKITE_COMMIT}"
+  export GIT_MERGE_AUTOEDIT="no"
+  export GIT_COMMITTER_EMAIL="foo@bar"
+  export GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin"
+  export GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
+  git merge "${BUILDKITE_COMMIT}"
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-function trigger() {
+trigger() {
   local pr="$1"
   local branch="$2"
   local slug="${BUILDKITE_PIPELINE_SLUG}"
   echo "Triggering merged build of ${slug} for PR ${pr}"
-  cat <<EOL | buildkite-agent pipeline upload 
+  cat <<EOL | buildkite-agent pipeline upload
   steps:
     - label: "Merge build"
       trigger: "${slug}"
@@ -20,7 +20,7 @@ function trigger() {
 EOL
 }
 
-function merge() {
+merge() {
   local target_branch="$1"
   if [[ -z "${target_branch}" ]] ; then
     echo "No pull request target branch"
@@ -29,7 +29,12 @@ function merge() {
 
   git fetch -v origin "${target_branch}"
   git checkout FETCH_HEAD
-  GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin" git merge "${BUILDKITE_COMMIT}"
+  # env vars to ensure merge is non-interactive
+  export GIT_MERGE_AUTOEDIT="no"
+  export GIT_COMMITTER_EMAIL="foo@bar"
+  export GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin"
+  export GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
+  git merge "${BUILDKITE_COMMIT} "
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"
@@ -56,4 +61,3 @@ else
   echo "Invalid mode: ${mode}"
   exit 1
 fi
-

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -30,11 +30,7 @@ merge() {
   git fetch -v origin "${target_branch}"
   git checkout FETCH_HEAD
   # env vars to ensure merge is non-interactive
-  export GIT_MERGE_AUTOEDIT="no"
-  export GIT_COMMITTER_EMAIL="foo@bar"
-  export GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin"
-  export GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
-  git merge "${BUILDKITE_COMMIT}"
+  GIT_MERGE_AUTOEDIT="no" GIT_COMMITTER_EMAIL="foo@bar" GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin" git merge "${BUILDKITE_COMMIT}"
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"


### PR DESCRIPTION
A few small changes in this PR

1. Added extra environment variables before the merge to ensure the merge is non-interactive
2. Removed the `function` keyword as per `shellcheck`'s [SC2112](https://github.com/koalaman/shellcheck/wiki/SC2112)

For `1`, we had issues running the plugin where it would ask for a commit message or it would complain about `user.email` not being configured. 

`GIT_MERGE_AUTOEDIT` ensure the editor is not invoked—[ref](https://git-scm.com/docs/merge-options/1.7.9.6#merge-options---no-edit)

One caveat is that I'm doing `export`s before the merge—this should be safe, but we can have them as a vars before the command 