### PR TITLE
Ensure non-interactive merge

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -29,7 +29,10 @@ function merge() {
 
   git fetch -v origin "${target_branch}"
   git checkout FETCH_HEAD
-  GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin" git merge "${BUILDKITE_COMMIT}"
+  GIT_COMMITTER_EMAIL="auto-merge@buildkite" \
+  GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin" \
+  GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin" \
+  git merge --no-edit "${BUILDKITE_COMMIT}"
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"


### PR DESCRIPTION
Similar to #12, but does not use export and uses "--no-edit" flag to ensure that editor is not brought up.

Before, failed (sometimes) with the following error:

    error: Terminal is dumb, but EDITOR unset

I cannot make out the necessary or sufficient condition to trigger this error. We had this work a couple times. It broke on a branch which had merges itself (but would apply cleanly).