### PR TITLE
Restore --no-edit flag  when merging

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -34,7 +34,7 @@ merge() {
   GIT_COMMITTER_EMAIL="auto-merge@buildkite" \
   GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
   GIT_MERGE_AUTOEDIT="no" \
-  git merge "${BUILDKITE_COMMIT}"
+  git merge --no-edit "${BUILDKITE_COMMIT}"
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -30,7 +30,7 @@ post_checkout_hook="$PWD/hooks/post-checkout"
   stub git \
     "fetch -v origin dev : echo FETCHED" \
     "checkout FETCH_HEAD : echo CHECKED_OUT" \
-    "merge deadbeef : echo MERGED"
+    "merge --no-edit deadbeef : echo MERGED"
 
   run "$post_checkout_hook"
 
@@ -48,7 +48,7 @@ post_checkout_hook="$PWD/hooks/post-checkout"
   stub git \
     "fetch -v origin master : echo FETCHED" \
     "checkout FETCH_HEAD : echo CHECKED_OUT" \
-    "merge deadbeef : echo MERGED"
+    "merge --no-edit deadbeef : echo MERGED"
 
   run "$post_checkout_hook"
 


### PR DESCRIPTION
This is a follow on from #12 where @timn  highlighted that `--no-edit` should be provided: https://github.com/seek-oss/github-merged-pr-buildkite-plugin/pull/12#issuecomment-433863270

