### PR TITLE
post-checkout: fix "empty ident name" error

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -32,7 +32,7 @@ merge() {
   # env vars to ensure merge is non-interactive
   GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin" \
   GIT_COMMITTER_EMAIL="auto-merge@buildkite" \
-  GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
+  GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin" \
   git merge --no-edit "${BUILDKITE_COMMIT}" || {
     local merge_result=$?
     echo "Merge failed: ${merge_result}"


### PR DESCRIPTION
There was a backslash missing in the latest version that prevents the author and commiter info environment variables to be passed along to the merge command. This leads to an error like
```empty ident name (for <buildkite-agent@host>) not allowed```.

Fix by adding that missing backslash.

I'd appreciate a speedy merge and release.