### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ When using `checkout` mode, the plugin should be specified on each build step (e
 
 ```yml
 plugins: &plugins
-  seek-oss/github-merged-pr#v1.0.1:
-    mode: checkout
+  - seek-oss/github-merged-pr#v1.0.1:
+      mode: checkout
 
 steps:
   - label: 'Make something'
@@ -54,8 +54,8 @@ steps:
     commands:
       - make something
     plugins:
-      seek-oss/github-merged-pr#v1.0.1:
-        mode: trigger
+      - seek-oss/github-merged-pr#v1.0.1:
+          mode: trigger
 
   - label: 'Make something else'
     commands:


### PR DESCRIPTION
Hi @zsims! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.