### PR TITLE
Add update_prs option to trigger mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Pull Request Plugin
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to build the merged state of pull requests.
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to build the merged state of pull requests and trigger new builds on PR branches after the default branch is changed.
 
 This means that builds will run against what the merged commit will be, rather than what is in the PR, reducing the risk of bad merges breaking master/trunk.
 
@@ -14,8 +14,8 @@ While this approach doesn't mitigate breaking changes made to the target branch 
 # Modes
 
 The plugin has two modes:
-  - `mode: trigger` to async trigger another build (of the current pipeline); and
-  - `mode: checkout` to merge the PR after checking out source
+  - `mode: checkout` to merge the PR after checking out source; and
+  - `mode: trigger` to async trigger another build (of the current pipeline)
 
 # Example
 
@@ -46,7 +46,8 @@ steps:
 ```
 
 ## Trigger Mode
-In `trigger` mode the plugin should only be specified on one step, to prevent triggering multiple builds.
+In `trigger` mode the plugin should only be specified on one step, to prevent triggering builds multiple times in a pipeline.
+When `update_prs` is set to `true` in this mode, pipelines on the default branch (e.g. `master`) will trigger new builds on all PR branches that still exist in the repository. If `oldest_pr` is set, any PR with an issue number lower than specified will be ignored when triggering new builds.
 
 ```yml
 steps:
@@ -56,6 +57,8 @@ steps:
     plugins:
       - seek-oss/github-merged-pr#v1.0.1:
           mode: trigger
+          update_prs: true
+          oldest_pr: 12
 
   - label: 'Make something else'
     commands:

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -20,6 +20,45 @@ trigger() {
 EOL
 }
 
+trigger_prs() {
+  git fetch origin
+
+  pr_limit="${BUILDKITE_PLUGIN_GITHUB_MERGED_PR_OLDEST_PR:-false}"
+  while read -r line; do
+    arr=($line)
+    sha="${arr[0]}"
+    pr=$(awk -F'/' '{print $3}' <<< "${arr[1]}")
+    if ! git merge-base --is-ancestor "${sha}" "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" 2>/dev/null; then
+      branch="$(set +e && git branch -a -q --contains "${sha}" 2>/dev/null | grep 'remotes/origin' | sed -e 's,^[[:space:]]*remotes/origin/,,g')"
+      if [[ "${branch}" != "" ]]; then
+        if [[ "${pr_limit}" == "false" ]] || [[ "${pr}" -ge "${pr_limit}" ]]; then
+          trigger_pr_branch "${pr}" "${branch}" "${sha}"
+        fi
+      fi
+    fi
+  done <<< "$(git ls-remote origin 'refs/pull/*/head')"
+}
+
+trigger_pr_branch() {
+  local pr="$1"
+  local branch="$2"
+  local commit="$3"
+  local slug="${BUILDKITE_PIPELINE_SLUG}"
+
+  echo "Triggering new build of ${slug} for PR ${pr}"
+  cat << EOL | buildkite-agent pipeline upload
+  steps:
+    - trigger: "${slug}"
+      async: true
+      build:
+        message: "Triggered by GitHub Merged PR plugin"
+        branch: "${branch}"
+        commit: "${commit}"
+        env:
+          BUILDKITE_PULL_REQUEST: "${pr}"
+EOL
+}
+
 merge() {
   local target_branch="$1"
   if [[ -z "${target_branch}" ]] ; then
@@ -48,19 +87,31 @@ if [[ -n "$force_merge" ]]; then
   exit $?
 fi
 
-# this is a pull request build
 pull_request="${BUILDKITE_PULL_REQUEST:-false}"
-if [[ "${pull_request}" == "false" ]] ; then
-  echo "Not a pull request, skipping"
-  exit 0
-fi
-
 mode="${BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE:-checkout}"
 if [[ "${mode}" == "checkout" ]]; then
+  if [[ "${pull_request}" == "false" ]]; then
+    echo "Not a pull request, skipping"
+    exit 0
+  fi
   merge "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
   exit $?
 elif [[ "${mode}" == "trigger" ]]; then
-  trigger "${pull_request}" "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}"
+  if [[ "${pull_request}" != "false" ]]; then
+    trigger "${pull_request}" "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}"
+    exit $?
+  fi
+  if [[ "${BUILDKITE_BRANCH}" != "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
+    echo "Not on default branch, skipping"
+    exit 0
+  fi
+  update_prs=${BUILDKITE_PLUGIN_GITHUB_MERGED_PR_UPDATE_PRS:-false}
+  if [[ ${update_prs} == "true" ]]; then
+    echo "Updating PRs"
+    trigger_prs
+    exit $?
+  fi
+  echo "Not configured to update PRs"
 else
   echo "Invalid mode: ${mode}"
   exit 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,6 +4,10 @@ author: https://github.com/seek-oss
 requirements: []
 configuration:
   properties:
-    cd:
+    mode:
       type: string
+    update_prs:
+      type: boolean
+    oldest_pr:
+      type: integer
   required: []

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -98,3 +98,101 @@ post_checkout_hook="$PWD/hooks/post-checkout"
   assert_success
   assert_output --partial "Not a pull request"
 }
+
+@test "Triggers PR builds on default branch" {
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE="trigger"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_UPDATE_PRS="true"
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="dev"
+  export BUILDKITE_BRANCH="dev"
+
+  stub buildkite-agent \
+    "pipeline upload : echo UPLOADED_PIPELINE"
+
+  stub git \
+    "fetch origin : echo FETCHED" \
+    "ls-remote origin 'refs/pull/*/head' : echo deadbeef refs/pull/123/head" \
+    "merge-base --is-ancestor deadbeef dev : echo UNMERGED && false" \
+    "branch -a -q --contains deadbeef : echo remotes/origin/MY_PR_BRANCH"
+
+  stub grep \
+    "remotes/origin : echo remotes/origin/MY_PR_BRANCH"
+
+  stub sed \
+    "-e 's,^[[:space:]]*remotes/origin/,,g' : echo MY_PR_BRANCH"
+
+  run "$post_checkout_hook"
+
+  assert_success
+  assert_output --partial "Updating PRs"
+  assert_output --partial "FETCHED"
+  assert_output --partial "Triggering new build of my-pipeline for PR 123"
+  assert_output --partial "UPLOADED_PIPELINE"
+  unstub buildkite-agent
+  unstub git
+  unstub grep
+  unstub sed
+}
+
+@test "Doesn't rebuild merged PR branches" {
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE="trigger"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_UPDATE_PRS="true"
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="dev"
+  export BUILDKITE_BRANCH="dev"
+
+  stub git \
+    "fetch origin : echo FETCHED" \
+    "ls-remote origin 'refs/pull/*/head' : echo deadbeef refs/pull/123/head" \
+    "merge-base --is-ancestor deadbeef dev : echo MERGED"
+
+  run "$post_checkout_hook"
+
+  assert_success
+  assert_output --partial "FETCHED"
+  assert_output --partial "MERGED"
+  unstub git
+}
+
+@test "Skips old unmerged PR branch" {
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE="trigger"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_UPDATE_PRS="true"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_OLDEST_PR="150"
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="dev"
+  export BUILDKITE_BRANCH="dev"
+
+  stub git \
+    "fetch origin : echo FETCHED" \
+    "ls-remote origin 'refs/pull/*/head' : echo deadbeef refs/pull/123/head" \
+    "merge-base --is-ancestor deadbeef dev : echo UNMERGED && false" \
+    "branch -a -q --contains deadbeef : echo remotes/origin/MY_PR_BRANCH"
+
+  stub grep \
+    "remotes/origin : echo remotes/origin/MY_PR_BRANCH"
+
+  stub sed \
+    "-e 's,^[[:space:]]*remotes/origin/,,g' : echo MY_PR_BRANCH"
+
+  run "$post_checkout_hook"
+
+  assert_success
+  assert_output --partial "FETCHED"
+  assert_output --partial "UNMERGED"
+  unstub git
+  unstub grep
+  unstub sed
+}
+
+@test "Does nothing on default branch when disabled" {
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE="trigger"
+  unset BUILDKITE_PLUGIN_GITHUB_MERGED_PR_UPDATE_PRS
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="dev"
+  export BUILDKITE_BRANCH="dev"
+
+  run "$post_checkout_hook"
+
+  assert_success
+  assert_output --partial "Not configured to update PRs"
+}


### PR DESCRIPTION
This PR adds an option to `trigger` mode which will trigger
builds on remaining PR branches when invoked on the default
branch.